### PR TITLE
Fix stale downloads fallback and contact form honeypot

### DIFF
--- a/client/src/components/ContactForm.tsx
+++ b/client/src/components/ContactForm.tsx
@@ -45,6 +45,7 @@ export default function ContactForm({
       formData.append('name', data.name);
       formData.append('email', data.email);
       formData.append('message', data.message);
+      formData.append('honeypot', data.honeypot || '');
       
       const response = await fetch('/', {
         method: 'POST',
@@ -91,17 +92,18 @@ export default function ContactForm({
       
       <div className="max-w-lg mx-auto">
         {/* Hidden form for Netlify detection */}
-        <form name="contact" data-netlify="true" data-netlify-honeypot="bot-field" hidden>
+        <form name="contact" data-netlify="true" data-netlify-honeypot="honeypot" hidden>
           <input type="text" name="name" />
           <input type="email" name="email" />
           <textarea name="message"></textarea>
+          <input type="text" name="honeypot" />
         </form>
         
         <form
           name="contact"
           method="POST"
           data-netlify="true"
-          data-netlify-honeypot="bot-field"
+          data-netlify-honeypot="honeypot"
           onSubmit={contactForm.handleSubmit(onContactSubmit)}
           className="space-y-4"
         >

--- a/client/src/components/downloads/DownloadHeroSection.tsx
+++ b/client/src/components/downloads/DownloadHeroSection.tsx
@@ -93,8 +93,8 @@ export default function DownloadHeroSection({ latestRelease, loading }: Download
           </div>
         ) : null}
 
-        {/* Fallback: Always show hardcoded downloads if API fails or no assets found */}
-        {(!latestRelease || !loading) && (
+        {/* Fallback: Show hardcoded downloads only if the GitHub API fails */}
+        {!latestRelease && !loading && (
           <div className="mt-8">
             <div className="text-center text-gray-400 text-sm mb-4">
               {!latestRelease ? 'API unavailable - showing latest known stable release:' : ''}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -42,7 +42,8 @@ export class MemStorage implements IStorage {
   async createContact(insertContact: InsertContact): Promise<Contact> {
     const id = randomUUID();
     const contact: Contact = { 
-      ...insertContact, 
+      ...insertContact,
+      honeypot: insertContact.honeypot || null,
       id, 
       createdAt: new Date() 
     };


### PR DESCRIPTION
## Summary
- Show the hardcoded download fallback only when the GitHub releases API is unavailable, preventing a duplicate row of stale v2.0.5 download cards when current release data loads successfully.
- Align the Netlify contact form honeypot field name between the detected hidden form and the submitted form data.
- Normalize the optional honeypot value in in-memory storage so TypeScript checks pass.

Fixes #18.
Fixes #19.

## Verification
- npm run check
- npm run build